### PR TITLE
`all_files` support for py-shinylive's base-deps function

### DIFF
--- a/shinylive/_deps.py
+++ b/shinylive/_deps.py
@@ -119,17 +119,19 @@ def _pyodide_pkg_infos_to_quarto_html_dep_items(
 # =============================================================================
 def shinylive_base_deps_htmldep(
     sw_dir: Optional[str] = None,
+    *,
+    all_files: bool = False,
 ) -> list[QuartoHtmlDependency]:
     return [
         _serviceworker_dep(sw_dir),
-        _shinylive_common_dep_htmldep(),
+        _shinylive_common_dep_htmldep(all_files=all_files),
     ]
 
 
 # =============================================================================
 # Common dependencies
 # =============================================================================
-def _shinylive_common_dep_htmldep() -> QuartoHtmlDependency:
+def _shinylive_common_dep_htmldep(*, all_files: bool = False) -> QuartoHtmlDependency:
     """
     Return an HTML dependency object consisting of files that are base dependencies; in
     other words, the files that are always included in a Shinylive deployment.
@@ -137,7 +139,7 @@ def _shinylive_common_dep_htmldep() -> QuartoHtmlDependency:
     assets_dir = shinylive_assets_dir()
 
     # First, get the list of base files.
-    base_files = shinylive_common_files()
+    base_files = shinylive_common_files(all_files=all_files)
 
     # Next, categorize the base files into scripts, stylesheets, and resources.
     scripts: list[str | HtmlDepItem] = []
@@ -208,7 +210,7 @@ def _shinylive_common_dep_htmldep() -> QuartoHtmlDependency:
     }
 
 
-def shinylive_common_files() -> list[str]:
+def shinylive_common_files(*, all_files: bool = False) -> list[str]:
     """
     Return a list of files that are base dependencies; in other words, the files that are
     always included in a Shinylive deployment.
@@ -224,6 +226,9 @@ def shinylive_common_files() -> list[str]:
             dirs.remove("export_template")
         elif rel_root == Path("shinylive"):
             files.remove("examples.json")
+            # Remove webr folder as it is only needed for R support
+            if not all_files:
+                dirs.remove("webr")
         elif rel_root == Path("shinylive/pyodide"):
             dirs.remove("fonts")
             files[:] = BASE_PYODIDE_FILES

--- a/shinylive/_export.py
+++ b/shinylive/_export.py
@@ -51,7 +51,11 @@ def export(
         f"Copying base Shinylive files from {assets_dir}/ to {destdir}/",
         file=sys.stderr,
     )
-    base_files = _deps.shinylive_common_files()
+
+    base_files = _deps.shinylive_common_files(
+        # Do not include r-only support files
+        all_files=False,
+    )
     for file in base_files:
         src_path = assets_dir / file
         dest_path = destdir / Path(file)

--- a/shinylive/_main.py
+++ b/shinylive/_main.py
@@ -188,8 +188,18 @@ def assets(
     default=None,
     help="Directory where shinylive-sw.js is located, relative to the output directory.",
 )
-def base_deps(sw_dir: Optional[str]) -> None:
-    deps = _deps.shinylive_base_deps_htmldep(sw_dir)
+# @click.option(
+#     "--all-files",
+#     is_flag=True,
+#     default=False,
+#     show_default=False,
+#     # help="Include all language dependencies, not just the ones needed for the application.",
+# )
+def base_deps(
+    sw_dir: Optional[str],
+    # all_files: Optional[bool]
+) -> None:
+    deps = _deps.shinylive_base_deps_htmldep(sw_dir, all_files=True)
     print(json.dumps(deps, indent=2))
 
 


### PR DESCRIPTION
Tested manually. The Quarto-ext calls the same function.