### PR TITLE
cli!: Move quarto extension methods under `extension`. Return core and python assets only

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.0.19] UNRELEASED
+
+* Adjusted cli api to have all quarto extension commands under `extension`. (#16)
+
 ## [0.0.18] - 2023-09-13
 
 ### Library updates

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.0.19] UNRELEASED
+## [UNRELEASED]
 
 * Adjusted cli api to have all quarto extension commands under `extension`. (#16)
 

--- a/README.md
+++ b/README.md
@@ -60,8 +60,8 @@ To see which version of this Python package you have, and which version of the w
 $ shinylive
 Usage: shinylive [OPTIONS] COMMAND [ARGS]...
 
-  shinylive Python package version: 0.0.1
-  shinylive web assets version:     0.0.6
+  shinylive Python package version: 0.1.0
+  shinylive web assets version:     0.2.1
 ...
 ```
 
@@ -69,7 +69,7 @@ The web assets will be downloaded and cached the first time you run `shinylive e
 
 ```
 $ shinylive assets download
-Downloading https://github.com/posit-dev/shinylive/releases/download/v0.0.6/shinylive-0.0.6.tar.gz...
+Downloading https://github.com/posit-dev/shinylive/releases/download/v0.2.1/shinylive-0.2.1.tar.gz...
 Unzipping to /Users/username/Library/Caches/shinylive/
 ```
 
@@ -81,21 +81,21 @@ $ shinylive assets info
     /Users/username/Library/Caches/shinylive
 
     Installed versions:
+    /Users/username/Library/Caches/shinylive/shinylive-0.2.1
     /Users/username/Library/Caches/shinylive/shinylive-0.0.6
-    /Users/username/Library/Caches/shinylive/shinylive-0.0.5
 ```
 
 You can remove old versions with `shinylive assets cleanup`. This will remove all versions except the one that the Python package wants to use:
 
 ```
 $ shinylive assets cleanup
-Keeping version 0.0.6
-Removing /Users/username/Library/Caches/shinylive/shinylive-0.0.5
-```
-
-If you want to force it to remove a specific version, use the `shinylive assets remove --version xxx`:
-
-```
-$ shinylive assets remove --version 0.0.6
+Keeping version 0.2.1
 Removing /Users/username/Library/Caches/shinylive/shinylive-0.0.6
+```
+
+If you want to force it to remove a specific version, use the `shinylive assets remove xxx`:
+
+```
+$ shinylive assets remove 0.2.1
+Removing /Users/username/Library/Caches/shinylive/shinylive-0.2.1
 ```

--- a/shinylive/_assets.py
+++ b/shinylive/_assets.py
@@ -164,13 +164,15 @@ def cleanup_shinylive_assets(
 
     shinylive_dir = Path(shinylive_dir)
 
-    version = _installed_shinylive_versions(shinylive_dir)
-    version = [re.sub("^shinylive-", "", os.path.basename(v)) for v in version]
-    if SHINYLIVE_ASSETS_VERSION in version:
+    version_paths = _installed_shinylive_version_paths(shinylive_dir)
+    version_names = [
+        re.sub("^shinylive-", "", os.path.basename(v)) for v in version_paths
+    ]
+    if SHINYLIVE_ASSETS_VERSION in version_names:
         print("Keeping version " + SHINYLIVE_ASSETS_VERSION)
-        version.remove(SHINYLIVE_ASSETS_VERSION)
+        version_names.remove(SHINYLIVE_ASSETS_VERSION)
 
-    remove_shinylive_assets(shinylive_dir, version)
+    remove_shinylive_assets(shinylive_dir, version_names)
 
 
 def remove_shinylive_assets(
@@ -213,14 +215,23 @@ def remove_shinylive_assets(
             print(f"{target_dir} does not exist.")
 
 
-def _installed_shinylive_versions(shinylive_dir: Optional[Path] = None) -> list[str]:
+def _installed_shinylive_version_paths(
+    shinylive_dir: Optional[Path] = None,
+) -> list[Path]:
     if shinylive_dir is None:
         shinylive_dir = Path(shinylive_cache_dir())
 
     shinylive_dir = Path(shinylive_dir)
     subdirs = shinylive_dir.iterdir()
-    subdirs = [re.sub("^shinylive-", "", str(s)) for s in subdirs]
-    return subdirs
+    # print(", ".join([str(s.name) for s in subdirs]))
+    return [s for s in subdirs if not s.name.startswith(".")]
+    subdir_names = [str(s.name) for s in subdirs]
+    versions = [
+        re.sub("^shinylive-", "", subdir_name)
+        for subdir_name in subdir_names
+        if not subdir_name.startswith(".")
+    ]
+    return versions
 
 
 def print_shinylive_local_info(
@@ -236,9 +247,9 @@ def print_shinylive_local_info(
     )
     if destdir.exists():
         print("""    Installed versions:""")
-        installed_versions = _installed_shinylive_versions(destdir)
-        if len(installed_versions) > 0:
-            print("    " + "\n    ".join(installed_versions))
+        installed_version_paths = _installed_shinylive_version_paths(destdir)
+        if len(installed_version_paths) > 0:
+            print("    " + "\n    ".join([str(v) for v in installed_version_paths]))
         else:
             print("    (None)")
     else:

--- a/shinylive/_assets.py
+++ b/shinylive/_assets.py
@@ -218,15 +218,20 @@ def _installed_shinylive_versions(shinylive_dir: Optional[Path] = None) -> list[
     return subdirs
 
 
-def print_shinylive_local_info() -> None:
+def print_shinylive_local_info(
+    destdir: Path | None = None,
+) -> None:
+    if destdir is None:
+        destdir = Path(shinylive_cache_dir())
+
     print(
         f"""    Local cached shinylive asset dir:
-    {shinylive_cache_dir()}
+    {str(destdir)}
     """
     )
-    if Path(shinylive_cache_dir()).exists():
+    if destdir.exists():
         print("""    Installed versions:""")
-        installed_versions = _installed_shinylive_versions()
+        installed_versions = _installed_shinylive_versions(destdir)
         if len(installed_versions) > 0:
             print("    " + "\n    ".join(installed_versions))
         else:

--- a/shinylive/_assets.py
+++ b/shinylive/_assets.py
@@ -73,6 +73,11 @@ def repodata_json_file(version: str = SHINYLIVE_ASSETS_VERSION) -> Path:
     )
 
 
+def codeblock_to_json_file() -> str:
+    p = Path(shinylive_assets_dir()) / "scripts" / "codeblock-to-json.js"
+    return str(p)
+
+
 def copy_shinylive_local(
     source_dir: str | Path,
     destdir: Optional[str | Path] = None,

--- a/shinylive/_deps.py
+++ b/shinylive/_deps.py
@@ -33,8 +33,7 @@ BASE_PYODIDE_FILES = {
 
 # Packages that should always be included in a Shinylive deployment.
 BASE_PYODIDE_PACKAGES = {"distutils", "micropip", "ssl"}
-# Must use Tuple as function signatures are mutable
-AssetFileType = Tuple[Literal["base", "python", "r"], ...]
+AssetType = Literal["base", "python", "r"]
 
 
 # =============================================================================
@@ -122,16 +121,16 @@ def _pyodide_pkg_infos_to_quarto_html_dep_items(
 def shinylive_base_deps_htmldep(
     sw_dir: Optional[str] = None,
     *,
-    file_type: AssetFileType = ("base",),
+    asset_type: Tuple[AssetType] = ("base",),
 ) -> list[QuartoHtmlDependency]:
     return [
         _serviceworker_dep(sw_dir),
-        _shinylive_common_dep_htmldep(file_type=file_type),
+        _shinylive_common_dep_htmldep(asset_type=asset_type),
     ]
 
 
 def shinylive_python_resources() -> list[HtmlDepItem]:
-    rel_paths = shinylive_common_files(file_type=("python",))
+    rel_paths = shinylive_common_files(asset_type=("python",))
     assets_dir = shinylive_assets_dir()
     return [
         {"name": rel_path, "path": os.path.join(assets_dir, rel_path)}
@@ -141,7 +140,7 @@ def shinylive_python_resources() -> list[HtmlDepItem]:
 
 # Not used in practice!
 def shinylive_r_resources() -> list[HtmlDepItem]:
-    rel_paths = shinylive_common_files(file_type=("r",))
+    rel_paths = shinylive_common_files(asset_type=("r",))
     assets_dir = shinylive_assets_dir()
     return [
         {"name": rel_path, "path": os.path.join(assets_dir, rel_path)}
@@ -154,7 +153,7 @@ def shinylive_r_resources() -> list[HtmlDepItem]:
 # =============================================================================
 def _shinylive_common_dep_htmldep(
     *,
-    file_type: AssetFileType = (
+    asset_type: AssetType = (
         "base",
         "python",
     ),
@@ -166,7 +165,7 @@ def _shinylive_common_dep_htmldep(
     assets_dir = shinylive_assets_dir()
 
     # First, get the list of base files.
-    base_files = shinylive_common_files(file_type=file_type)
+    base_files = shinylive_common_files(asset_type=asset_type)
 
     # Next, categorize the base files into scripts, stylesheets, and resources.
     scripts: list[str | HtmlDepItem] = []
@@ -234,16 +233,16 @@ def _shinylive_common_dep_htmldep(
 
 def shinylive_common_files(
     *,
-    file_type: AssetFileType,
+    asset_type: AssetType,
 ) -> list[str]:
     """
     Return a list of asset files for Python, and/or R, and/or language-agnostic (base) dependencies
     """
     ensure_shinylive_assets()
 
-    has_base = "base" in file_type
-    has_python = "python" in file_type
-    has_r = "r" in file_type
+    has_base = "base" in asset_type
+    has_python = "python" in asset_type
+    has_r = "r" in asset_type
 
     base_files: list[str] = []
     for root, dirs, files in os.walk(shinylive_assets_dir()):

--- a/shinylive/_deps.py
+++ b/shinylive/_deps.py
@@ -153,7 +153,7 @@ def shinylive_r_resources() -> list[HtmlDepItem]:
 # =============================================================================
 def _shinylive_common_dep_htmldep(
     *,
-    asset_type: AssetType = (
+    asset_type: Tuple[AssetType, ...] = (
         "base",
         "python",
     ),
@@ -233,7 +233,7 @@ def _shinylive_common_dep_htmldep(
 
 def shinylive_common_files(
     *,
-    asset_type: AssetType,
+    asset_type: Tuple[AssetType, ...],
 ) -> list[str]:
     """
     Return a list of asset files for Python, and/or R, and/or language-agnostic (base) dependencies

--- a/shinylive/_deps.py
+++ b/shinylive/_deps.py
@@ -358,8 +358,9 @@ def find_package_deps(
 
 def base_package_deps_htmldepitems() -> list[HtmlDepItem]:
     """
-    Return list of packages that should be included in all Shinylive deployments. The
-    returned data structure is a list of PyodidePackageInfo objects.
+    Return list of python packages that should be included in all python Shinylive
+    deployments. The returned data structure is a list of HtmlDepItem objects
+    representing PyodidePackageInfo objects.
     """
     pkg_infos = base_package_deps()
     deps = _pyodide_pkg_infos_to_quarto_html_dep_items(pkg_infos)
@@ -369,8 +370,8 @@ def base_package_deps_htmldepitems() -> list[HtmlDepItem]:
 
 def base_package_deps() -> list[PyodidePackageInfo]:
     """
-    Return list of packages that should be included in all Shinylive deployments. The
-    returned data structure is a list of PyodidePackageInfo objects.
+    Return list of python packages that should be included in all python Shinylive
+    deployments. The returned data structure is a list of PyodidePackageInfo objects.
     """
     dep_names = _find_recursive_deps(BASE_PYODIDE_PACKAGES)
     pkg_infos = _dep_names_to_pyodide_pkg_infos(dep_names)

--- a/shinylive/_deps.py
+++ b/shinylive/_deps.py
@@ -237,8 +237,7 @@ def shinylive_common_files(
     file_type: AssetFileType,
 ) -> list[str]:
     """
-    Return a list of files that are base dependencies; in other words, the files that are
-    always included in a Shinylive deployment.
+    Return a list of asset files for Python, and/or R, and/or language-agnostic (base) dependencies
     """
     ensure_shinylive_assets()
 

--- a/shinylive/_deps.py
+++ b/shinylive/_deps.py
@@ -130,12 +130,22 @@ def shinylive_base_deps_htmldep(
 
 
 def shinylive_python_resources() -> list[HtmlDepItem]:
+    ret: list[HtmlDepItem] = []
+
+    # Add python support file
     rel_paths = shinylive_common_files(asset_type=("python",))
     assets_dir = shinylive_assets_dir()
-    return [
-        {"name": rel_path, "path": os.path.join(assets_dir, rel_path)}
-        for rel_path in rel_paths
-    ]
+    ret.extend(
+        [
+            {"name": rel_path, "path": os.path.join(assets_dir, rel_path)}
+            for rel_path in rel_paths
+        ]
+    )
+
+    # Add base python packages as resources
+    ret.extend(base_package_deps_htmldepitems())
+
+    return ret
 
 
 # Not used in practice!
@@ -201,9 +211,6 @@ def _shinylive_common_dep_htmldep(
                     "path": os.path.join(assets_dir, file),
                 }
             )
-
-    # Add base python packages as resources
-    resources.extend(base_package_deps_htmldepitems())
 
     # Sort scripts so that load-shinylive-sw.js is first, and run-python-blocks.js is
     # last.
@@ -302,7 +309,6 @@ def _serviceworker_dep(sw_dir: Optional[str] = None) -> QuartoHtmlDependency:
 def shinylive_app_resources(
     json_file: Optional[str | Path],
     json_content: Optional[str],
-    verbose: bool = True,
 ) -> list[HtmlDepItem]:
     """
     Find package dependencies from an app.json file, and return as a list of
@@ -315,10 +321,6 @@ def shinylive_app_resources(
         json_file is not None and json_content is not None
     ):
         raise RuntimeError("Must provide either `json_file` or `json_content`.")
-
-    def verbose_print(*args: object) -> None:
-        if verbose:
-            print(*args, file=sys.stderr)
 
     file_contents: list[FileContentJson] = []
 

--- a/shinylive/_export.py
+++ b/shinylive/_export.py
@@ -54,7 +54,7 @@ def export(
 
     base_files = _deps.shinylive_common_files(
         # Do not include r-only support files
-        all_files=False,
+        kind=c("base", "python"),
     )
     for file in base_files:
         src_path = assets_dir / file

--- a/shinylive/_export.py
+++ b/shinylive/_export.py
@@ -54,7 +54,7 @@ def export(
 
     base_files = _deps.shinylive_common_files(
         # Do not include r-only support files
-        kind=c("base", "python"),
+        file_type=("base", "python"),
     )
     for file in base_files:
         src_path = assets_dir / file

--- a/shinylive/_export.py
+++ b/shinylive/_export.py
@@ -54,7 +54,7 @@ def export(
 
     base_files = _deps.shinylive_common_files(
         # Do not include r-only support files
-        file_type=("base", "python"),
+        asset_type=("base", "python"),
     )
     for file in base_files:
         src_path = assets_dir / file

--- a/shinylive/_main.py
+++ b/shinylive/_main.py
@@ -9,15 +9,36 @@ import click
 
 from . import _assets, _deps, _export, _version
 
+version_txt = f"""
+    \b
+    shinylive Python package version: {_version.SHINYLIVE_PACKAGE_VERSION}
+    shinylive web assets version:     {_assets.SHINYLIVE_ASSETS_VERSION}
+"""
+
+# CLI structure:
+# * shinylive
+#     * --version
+#     * export
+#         * Options: --verbose, --subdir, --full-shinylive
+#     * assets
+#         * download
+#             * Options: --version, --dir, --url
+#         * cleanup
+#             * Options: --dir
+#         * remove
+#             * Options: --version (required), --dir
+#         * info
+#             * Options: --dir
+#         * install-from-local
+#             * Options: --version, --dir, --source (required)
+#         * link-from-local
+#             * Options: --version, --dir, --source (required)
+#         * version
 
 @click.group(
     invoke_without_command=True,
     no_args_is_help=True,
-    help=f"""
-    \b
-    shinylive Python package version: {_version.SHINYLIVE_PACKAGE_VERSION}
-    shinylive web assets version:     {_assets.SHINYLIVE_ASSETS_VERSION}
-""",
+    help=version_txt,
 )
 @click.option(
     "--version",
@@ -29,6 +50,14 @@ from . import _assets, _deps, _export, _version
 def main(version: bool) -> None:
     if version:
         print(_version.SHINYLIVE_PACKAGE_VERSION)
+        # Quit early without error
+        # Prevents `shinylive --version assets` from executing `assets` command
+        click.get_current_context().exit(0)
+
+
+# #############################################################################
+# ## Export
+# #############################################################################
 
 
 @main.command(
@@ -87,93 +116,189 @@ def export(
     )
 
 
-@main.command(
+# #############################################################################
+# ## Assets
+# #############################################################################
+
+
+@main.group(
     help=f"""Manage local copy of Shinylive web assets
-
-    \b
-    shinylive Python package version: {_version.SHINYLIVE_PACKAGE_VERSION}
-    shinylive web assets version:     {_assets.SHINYLIVE_ASSETS_VERSION}
-
-    \b
-    Commands:
-      download: Download assets from the remote server.
-      cleanup: Remove all versions of local assets except the currently-used version, {_assets.SHINYLIVE_ASSETS_VERSION}.
-      remove: Remove a specific version of local copies of assets. Must be used with --version.
-      info: Print information about the local assets.
-      install-from-local: Install shinylive assets from a local directory. Must be used with --source.
-      link-from-local: Create a symlink to shinylive assets from a local shinylive build directory. Must be used with --source. This is useful when doing development on the Shinylive web assets.
-
+    {version_txt}
 """,
     no_args_is_help=True,
 )
-@click.argument("command", type=str)
+def assets() -> None:
+    pass
+
+
+def upgrade_dir(dir: str | Path | None) -> Path:
+    if dir is None:
+        dir = _assets.shinylive_cache_dir()
+    dir = Path(dir)
+    return dir
+
+
+@assets.command(help="""Download assets from the remote server.""")
 @click.option(
     "--version",
     type=str,
-    default=None,
-    help="Shinylive version to download or remove.",
-    show_default=True,
-)
-@click.option(
-    "--url",
-    type=str,
-    default=None,
-    help="URL to download from. If used, this will override --version.",
+    default=_version.SHINYLIVE_ASSETS_VERSION,
+    help="Shinylive version to download.",
     show_default=True,
 )
 @click.option(
     "--dir",
     type=str,
     default=None,
-    help="Directory to store shinylive assets (if not using the default)",
+    help="Directory to store shinylive assets (if not using the default).",
+)
+@click.option(
+    "--url",
+    type=str,
+    default=None,
+    help="URL to download from. If used, this will override --version.",
+)
+def download(
+    version: str,
+    dir: Optional[str | Path],
+    url: Optional[str],
+) -> None:
+    if version is None:  # pyright: ignore[reportUnnecessaryComparison]
+        version = _version.SHINYLIVE_ASSETS_VERSION
+    _assets.download_shinylive(destdir=upgrade_dir(dir), version=version, url=url)
+
+
+@assets.command(
+    help=f"Remove all versions of local assets except the currently-used version, {_assets.SHINYLIVE_ASSETS_VERSION}."
+)
+@click.option(
+    "--dir",
+    type=str,
+    default=None,
+    help="Directory where shinylive assets are stored (if not using the default).",
+)
+def cleanup(
+    dir: Optional[str | Path],
+) -> None:
+    _assets.cleanup_shinylive_assets(shinylive_dir=upgrade_dir(dir))
+
+
+@assets.command(
+    help="Remove a specific version of local copies of assets.",
+    no_args_is_help=True,
+)
+@click.option(
+    "--version",
+    type=str,
+    help="Shinylive version to remove.",
+    required=True,
+)
+@click.option(
+    "--dir",
+    type=str,
+    default=None,
+    help="Directory where shinylive assets are stored (if not using the default).",
+)
+def remove(
+    version: str,
+    dir: Optional[str | Path],
+) -> None:
+    if version is None:  # pyright: ignore[reportUnnecessaryComparison]
+        raise click.UsageError("Must specify --version")
+    dir = upgrade_dir(dir)
+    _assets.remove_shinylive_assets(shinylive_dir=dir, version=version)
+
+
+@assets.command(
+    name="info",
+    help="Print information about the local assets.",
+)
+@click.option(
+    "--dir",
+    type=str,
+    default=None,
+    help="Directory where shinylive assets are stored (if not using the default).",
+)
+def assets_info(
+    dir: Optional[str | Path],
+) -> None:
+    _assets.print_shinylive_local_info(destdir=upgrade_dir(dir))
+
+
+@assets.command(
+    help="Install shinylive assets from a local directory.",
+    no_args_is_help=True,
+)
+@click.option(
+    "--version",
+    type=str,
+    default=_version.SHINYLIVE_ASSETS_VERSION,
+    help="Version of the shinylive assets being copied.",
+    show_default=True,
+)
+@click.option(
+    "--dir",
+    type=str,
+    default=None,
+    help="Directory to store shinylive assets (if not using the default).",
 )
 @click.option(
     "--source",
     type=str,
     default=None,
-    help="Directory where shinylive assets will be copied from. Must be used with 'copy' command.",
+    help="Directory where shinylive assets will be copied from.",
+    required=True,
 )
-def assets(
-    command: str,
-    version: Optional[str],
-    url: Optional[str],
+def install_from_local(
+    source: str,
+    version: str,
     dir: Optional[str | Path],
-    source: Optional[str],
 ) -> None:
-    if dir is None:
-        dir = _assets.shinylive_cache_dir()
-    dir = Path(dir)
+    if source is None:  # pyright: ignore[reportUnnecessaryComparison]
+        raise click.UsageError("Must specify --source")
+    dir = upgrade_dir(dir)
+    if version is None:  # pyright: ignore[reportUnnecessaryComparison]
+        version = _version.SHINYLIVE_ASSETS_VERSION
+    print(f"Copying shinylive-{version} from {source} to {dir}")
+    _assets.copy_shinylive_local(source_dir=source, destdir=dir, version=version)
 
-    if command == "download":
-        if version is None:
-            version = _version.SHINYLIVE_ASSETS_VERSION
-        _assets.download_shinylive(destdir=dir, version=version, url=url)
-    elif command == "cleanup":
-        _assets.cleanup_shinylive_assets(shinylive_dir=dir)
-    elif command == "remove":
-        if version is None:
-            raise click.UsageError("Must specify --version")
-        _assets.remove_shinylive_assets(shinylive_dir=dir, version=version)
-    elif command == "info":
-        _assets.print_shinylive_local_info()
-    elif command == "install-from-local":
-        if source is None:
-            raise click.UsageError("Must specify --source")
-        if version is None:
-            version = _version.SHINYLIVE_ASSETS_VERSION
-        print(f"Copying shinylive-{version} from {source} to {dir}")
-        _assets.copy_shinylive_local(source_dir=source, destdir=dir, version=version)
-    elif command == "link-from-local":
-        if source is None:
-            raise click.UsageError("Must specify --source")
-        if version is None:
-            version = _version.SHINYLIVE_ASSETS_VERSION
-        print(f"Creating symlink for shinylive-{version} from {source} to {dir}")
-        _assets.link_shinylive_local(source_dir=source, destdir=dir, version=version)
-    elif command == "version":
-        print(_assets.SHINYLIVE_ASSETS_VERSION)
-    else:
-        raise click.UsageError(f"Unknown command: {command}")
+
+@assets.command(
+    help="""Create a symlink to shinylive assets from a local shinylive build directory.""",
+    no_args_is_help=True,
+)
+@click.option(
+    "--version",
+    type=str,
+    default=_version.SHINYLIVE_ASSETS_VERSION,
+    help="Version of shinylive assets being linked.",
+    show_default=True,
+)
+@click.option(
+    "--dir",
+    type=str,
+    default=None,
+    help="Directory to store shinylive assets (if not using the default).",
+)
+@click.option(
+    "--source",
+    type=str,
+    default=None,
+    help="Directory where shinylive assets will be linked from.",
+    required=True,
+)
+def link_from_local(
+    source: str,
+    version: str,
+    dir: Optional[str | Path],
+) -> None:
+    if source is None:  # pyright: ignore[reportUnnecessaryComparison]
+        raise click.UsageError("Must specify --source")
+    dir = upgrade_dir(dir)
+    if version is None:  # pyright: ignore[reportUnnecessaryComparison]
+        version = _version.SHINYLIVE_ASSETS_VERSION
+    print(f"Creating symlink for shinylive-{version} from {source} to {dir}")
+    _assets.link_shinylive_local(source_dir=source, destdir=dir, version=version)
 
 
 @main.command(

--- a/shinylive/_main.py
+++ b/shinylive/_main.py
@@ -373,7 +373,9 @@ def extension_info() -> None:
 def base_htmldeps(
     sw_dir: Optional[str] = None,
 ) -> None:
-    print_as_json(_deps.shinylive_base_deps_htmldep(sw_dir=sw_dir, file_type=("base",)))
+    print_as_json(
+        _deps.shinylive_base_deps_htmldep(sw_dir=sw_dir, asset_type=("base",))
+    )
     return
 
 

--- a/shinylive/_main.py
+++ b/shinylive/_main.py
@@ -72,19 +72,11 @@ version_txt = f"""
     help=version_txt,
     cls=OrderedGroup,
 )
-@click.option(
-    "--version",
-    is_flag=True,
-    default=False,
-    help="Print version of shinylive python package.",
-    show_default=True,
-)
-def main(version: bool) -> None:
-    if version:
-        print(_version.SHINYLIVE_PACKAGE_VERSION)
-        # Quit early without error
-        # Prevents `shinylive --version assets` from executing `assets` command
-        click.get_current_context().exit(0)
+# > Add a --version option which immediately prints the version number and exits the
+# > program.
+@click.version_option(_version.SHINYLIVE_PACKAGE_VERSION, message="%(version)s")
+def main() -> None:
+    ...
 
 
 # #############################################################################

--- a/shinylive/_main.py
+++ b/shinylive/_main.py
@@ -43,14 +43,14 @@ version_txt = f"""
 #             * Options: --version, --dir, --url
 #         * cleanup
 #             * Options: --dir
-#         * remove
-#             * Options: --version (required), --dir
+#         * remove VERSION
+#             * Options: --dir
 #         * info
 #             * Options: --dir
-#         * install-from-local
-#             * Options: --version, --dir, --source (required)
-#         * link-from-local
-#             * Options: --version, --dir, --source (required)
+#         * install-from-local BUILD
+#             * Options: --version, --dir
+#         * link-from-local BUILD
+#             * Options: --version, --dir
 #         * version
 #     * extension
 #         * info
@@ -231,13 +231,16 @@ def cleanup(
 
 
 @assets.command(
-    help="Remove a specific version of local copies of assets.",
+    short_help="Remove a specific version of local copies of assets.",
+    help=f"""Remove a specific version (`VERSION`) of local copies of assets."
+
+    For example, `VERSION` might be `{ _version.SHINYLIVE_ASSETS_VERSION }`.
+    """,
     no_args_is_help=True,
 )
-@click.option(
-    "--version",
+@click.argument(
+    "version",
     type=str,
-    help="Shinylive version to remove.",
     required=True,
 )
 @click.option(
@@ -256,14 +259,12 @@ def remove(
     _assets.remove_shinylive_assets(shinylive_dir=dir, version=version)
 
 
-install_from_local_help = (
-    "Install shinylive assets from a local shinylive build directory."
-)
-
-
 @assets.command(
-    short_help=install_from_local_help,
-    help=install_from_local_help,
+    short_help="Install shinylive assets from a local shinylive build directory.",
+    help="""Install shinylive assets from a local shinylive build directory (`BUILD`).
+
+    For example, `BUILD` might be the `./build` directory of a local shinylive repository.
+    """,
     no_args_is_help=True,
 )
 @click.option(
@@ -279,11 +280,9 @@ install_from_local_help = (
     default=None,
     help="Directory to store shinylive assets (if not using the default).",
 )
-@click.option(
-    "--source",
+@click.argument(
+    "BUILD",
     type=str,
-    default=None,
-    help="Directory where shinylive assets will be copied from (for example, shinylive build directory).",
     required=True,
 )
 def install_from_local(
@@ -306,8 +305,11 @@ link_from_local_help = (
 
 
 @assets.command(
-    short_help=link_from_local_help,
-    help=link_from_local_help,
+    short_help="Create a symlink to shinylive assets from a local shinylive build directory.",
+    help="""Create a symlink to shinylive assets from a local shinylive build directory (`BUILD`).
+
+    For example, `BUILD` might be the `./build` directory of a local shinylive repository.
+    """,
     no_args_is_help=True,
 )
 @click.option(
@@ -323,25 +325,23 @@ link_from_local_help = (
     default=None,
     help="Directory to store shinylive assets (if not using the default).",
 )
-@click.option(
-    "--source",
+@click.argument(
+    "build",
     type=str,
-    default=None,
-    help="Directory where shinylive assets will be linked from (for example, shinylive build directory).",
     required=True,
 )
 def link_from_local(
-    source: str,
+    build: str,
     version: str,
     dir: Optional[str | Path],
 ) -> None:
-    if source is None:  # pyright: ignore[reportUnnecessaryComparison]
-        raise click.UsageError("Must specify --source")
+    if build is None:  # pyright: ignore[reportUnnecessaryComparison]
+        raise click.UsageError("Must specify BUILD")
     dir = upgrade_dir(dir)
     if version is None:  # pyright: ignore[reportUnnecessaryComparison]
         version = _version.SHINYLIVE_ASSETS_VERSION
-    print(f"Creating symlink for shinylive-{version} from {source} to {dir}")
-    _assets.link_shinylive_local(source_dir=source, destdir=dir, version=version)
+    print(f"Creating symlink for shinylive-{version} from {build} to {dir}")
+    _assets.link_shinylive_local(source_dir=build, destdir=dir, version=version)
 
 
 @assets.command(

--- a/shinylive/_main.py
+++ b/shinylive/_main.py
@@ -1,13 +1,31 @@
 from __future__ import annotations
 
+import collections
 import json
 import sys
 from pathlib import Path
-from typing import Optional
+from typing import MutableMapping, Optional
 
 import click
 
 from . import _assets, _deps, _export, _version
+
+
+# Make sure commands are listed in the order they are added in the code.
+class OrderedGroup(click.Group):
+    def __init__(
+        self,
+        name: Optional[str] = None,
+        commands: Optional[MutableMapping[str, click.Command]] = None,
+        **kwargs: object,
+    ):
+        super(OrderedGroup, self).__init__(name, commands, **kwargs)
+        #: the registered subcommands by their exported names.
+        self.commands = commands or collections.OrderedDict()
+
+    def list_commands(self, ctx: click.Context) -> list[str]:
+        return list(self.commands.keys())
+
 
 version_txt = f"""
     \b
@@ -52,6 +70,7 @@ version_txt = f"""
     invoke_without_command=True,
     no_args_is_help=True,
     help=version_txt,
+    cls=OrderedGroup,
 )
 @click.option(
     "--version",
@@ -139,6 +158,7 @@ def export(
     {version_txt}
 """,
     no_args_is_help=True,
+    cls=OrderedGroup,
 )
 def assets() -> None:
     pass
@@ -334,6 +354,7 @@ def version() -> None:
     All values are returned as JSON to stdout.
     {version_txt}
 """,
+    cls=OrderedGroup,
 )
 def extension() -> None:
     pass

--- a/shinylive/_main.py
+++ b/shinylive/_main.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import collections
-import json
 import sys
 from pathlib import Path
 from typing import MutableMapping, Optional
@@ -9,6 +8,7 @@ from typing import MutableMapping, Optional
 import click
 
 from . import _assets, _deps, _export, _version
+from ._utils import print_as_json
 
 
 # Make sure commands are listed in the order they are added in the code.
@@ -37,7 +37,7 @@ version_txt = f"""
 # * shinylive
 #     * --version
 #     * export
-#         * Options: --verbose, --subdir, --full-shinylive
+#         * Options: --subdir, --full-shinylive, --verbose
 #     * assets
 #         * download
 #             * Options: --version, --dir, --url
@@ -452,38 +452,38 @@ def app_resources(
     return
 
 
-@main.command(
-    help="""Please update your Quarto shinylive extension to the latest version.""",
-    hidden=True,
-    deprecated=True,
-)
+def defunct_help(cmd: str) -> str:
+    return f"""The shinylive CLI command `{cmd}` is defunct.
+
+You are using a newer version of the Python shinylive package ({ _version.SHINYLIVE_PACKAGE_VERSION }) with an older
+version of the Quarto shinylive extension, and these versions are not compatible.
+
+Please update your Quarto shinylive extension by running this command in the top level
+of your Quarto project:
+
+    quarto add quarto-ext/shinylive
+"""
+
+
+def defunct_error_txt(cmd: str) -> str:
+    return f"Error: { defunct_help(cmd) }"
+
+
+def raise_defunct(cmd: str) -> None:
+    # By raising a `SystemExit()`, we avoid printing the traceback.
+    raise SystemExit(defunct_error_txt(cmd))
+
+
+@main.command(help=defunct_help("base-deps"), hidden=True)
 def base_deps() -> None:
-    raise RuntimeError(
-        "This command is deprecated. Please update your Quarto shinylive extension."
-    )
+    raise_defunct("base-deps")
 
 
-@main.command(
-    help="""Please update your Quarto shinylive extension to the latest version.""",
-    hidden=True,
-    deprecated=True,
-)
+@main.command(help=defunct_help("package-deps"), hidden=True)
 def package_deps() -> None:
-    raise RuntimeError(
-        "This command is deprecated. Please update your Quarto shinylive extension."
-    )
+    raise_defunct("package-deps")
 
 
-@main.command(
-    help="""Please update your Quarto shinylive extension to the latest version.""",
-    hidden=True,
-    deprecated=True,
-)
+@main.command(help=defunct_help("codeblock-to-json"), hidden=True)
 def codeblock_to_json() -> None:
-    raise RuntimeError(
-        "This command is deprecated. Please update your Quarto shinylive extension."
-    )
-
-
-def print_as_json(x: object) -> None:
-    print(json.dumps(x, indent=None))
+    raise_defunct("codeblock-to-json")

--- a/shinylive/_main.py
+++ b/shinylive/_main.py
@@ -256,8 +256,14 @@ def remove(
     _assets.remove_shinylive_assets(shinylive_dir=dir, version=version)
 
 
+install_from_local_help = (
+    "Install shinylive assets from a local shinylive build directory."
+)
+
+
 @assets.command(
-    help="Install shinylive assets from a local directory.",
+    short_help=install_from_local_help,
+    help=install_from_local_help,
     no_args_is_help=True,
 )
 @click.option(
@@ -277,7 +283,7 @@ def remove(
     "--source",
     type=str,
     default=None,
-    help="Directory where shinylive assets will be copied from.",
+    help="Directory where shinylive assets will be copied from (for example, shinylive build directory).",
     required=True,
 )
 def install_from_local(
@@ -321,7 +327,7 @@ link_from_local_help = (
     "--source",
     type=str,
     default=None,
-    help="Directory where shinylive assets will be linked from.",
+    help="Directory where shinylive assets will be linked from (for example, shinylive build directory).",
     required=True,
 )
 def link_from_local(

--- a/shinylive/_utils.py
+++ b/shinylive/_utils.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import filecmp
+import json
 import os
 import shutil
 import sys
@@ -117,3 +118,7 @@ def tar_safe_extractall(file: str | Path, destdir: str | Path) -> None:
                 raise RuntimeError("Attempted path traversal in tar file.")
 
         tar.extractall(destdir)
+
+
+def print_as_json(x: object) -> None:
+    print(json.dumps(x, indent=None))

--- a/shinylive/_version.py
+++ b/shinylive/_version.py
@@ -1,5 +1,5 @@
 # The version of this Python package.
-SHINYLIVE_PACKAGE_VERSION = "0.0.18"
+SHINYLIVE_PACKAGE_VERSION = "0.0.19"
 
 # This is the version of the Shinylive assets to use.
 SHINYLIVE_ASSETS_VERSION = "0.2.0"

--- a/shinylive/_version.py
+++ b/shinylive/_version.py
@@ -1,5 +1,5 @@
 # The version of this Python package.
-SHINYLIVE_PACKAGE_VERSION = "0.0.19"
+SHINYLIVE_PACKAGE_VERSION = "0.1.0"
 
 # This is the version of the Shinylive assets to use.
-SHINYLIVE_ASSETS_VERSION = "0.2.0"
+SHINYLIVE_ASSETS_VERSION = "0.2.1"


### PR DESCRIPTION
Related: https://github.com/posit-dev/r-shinylive/pull/21

- [x] News