### PR TITLE
Update `py.typed` in package data

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -57,7 +57,7 @@ dev =
 include = shinylive, shinylive.*
 
 [options.package_data]
-shiny = py.typed
+shinylive = py.typed
 
 [options.entry_points]
 console_scripts =


### PR DESCRIPTION
Fixes a small typo that used `shiny =` instead of `shinylive =`