### PR TITLE
Fix detection of dependencies where key and name differ

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+
+## [UNRELEASED]
+
+* Fixed a problem with dependency detection when the package name differed from the key in package-lock.json (#36).
+
 ## [0.5.0] - 2025-07-18
 
 * Updated to Shinylive web assets 0.5.0.

--- a/shinylive/_deps.py
+++ b/shinylive/_deps.py
@@ -632,6 +632,9 @@ def _find_packages_in_requirements(req_txt: str) -> list[str]:
             # If we got here, it's a package specification.
             # Remove any trailing version info: "my-package (>= 1.0.0)" -> "my-package"
             pkg_name = re.sub(r"([a-zA-Z0-9._-]+)(.*)", r"\1", line).strip()
+            # Replace underscores with hyphens: "typing_extensions" -> "typing-extensions"
+            pkg_name = pkg_name.replace("_", "-")
+
             reqs.append(pkg_name)
 
     return reqs

--- a/shinylive/_deps.py
+++ b/shinylive/_deps.py
@@ -440,12 +440,15 @@ def dep_name_to_dep_key(name: str) -> str:
     The keys in pyodide-lock.json are not the same as the package names. For example,
     the key "jsonschema-specifications" points to an object where the "name" entry is
     "jsonschema_specifications".
+
+    Note that the names are lowercased because the package names should be treated as
+    case-insensitive. https://github.com/pyodide/pyodide/issues/1614
     """
     # Special case for base pyodide packages
     if name in BASE_PYODIDE_PACKAGE_NAMES:
         return name
 
-    return _dep_name_to_dep_key_mappings()[name]
+    return _dep_name_to_dep_key_mappings()[name.lower()]
 
 
 @functools.lru_cache
@@ -455,12 +458,16 @@ def _dep_name_to_dep_key_mappings() -> dict[str, str]:
     sometimes the package name and package key are different. For example, the package
     name is "jsonschema_specifications", but the package name is
     "jsonschema-specifications".
+
+    Note that the names are lowercased because the package names should be treated as
+    case-insensitive. https://github.com/pyodide/pyodide/issues/1614
     """
     name_to_key: dict[str, str] = {}
 
     pyodide_lock = _pyodide_lock_data()
     for key, pkg_info in pyodide_lock["packages"].items():
-        name_to_key[pkg_info["name"]] = key
+        name = pkg_info["name"].lower()
+        name_to_key[name] = key
 
     return name_to_key
 

--- a/shinylive/_deps.py
+++ b/shinylive/_deps.py
@@ -468,7 +468,7 @@ def _find_requirements_app_contents(app_contents: list[FileContentJson]) -> set[
     """
     packages: set[str] = set()
     for file_content in app_contents:
-        if not file_content["name"] != "requirements.txt":
+        if file_content["name"] != "requirements.txt":
             continue
 
         packages = packages.union(

--- a/shinylive/_deps.py
+++ b/shinylive/_deps.py
@@ -465,7 +465,7 @@ def _dep_name_to_dep_key_mappings() -> dict[str, str]:
     """
     Return a dictionary that maps package names to keys. This is needed because
     sometimes the package name and package key are different. For example, the package
-    name is "jsonschema_specifications", but the package name is
+    name is "jsonschema_specifications", but the package key is
     "jsonschema-specifications".
 
     Note that the names are lowercased because the package names should be treated as

--- a/shinylive/_deps.py
+++ b/shinylive/_deps.py
@@ -631,7 +631,7 @@ def _find_packages_in_requirements(req_txt: str) -> list[str]:
         else:
             # If we got here, it's a package specification.
             # Remove any trailing version info: "my-package (>= 1.0.0)" -> "my-package"
-            pkg_name = re.sub(r"([a-zA-Z0-9._-]+)(.*)", r"\\1", line).strip()
+            pkg_name = re.sub(r"([a-zA-Z0-9._-]+)(.*)", r"\1", line).strip()
             reqs.append(pkg_name)
 
     return reqs

--- a/shinylive/_version/__init__.py
+++ b/shinylive/_version/__init__.py
@@ -1,5 +1,5 @@
 # The version of this Python package.
-SHINYLIVE_PACKAGE_VERSION = "0.5.0"
+SHINYLIVE_PACKAGE_VERSION = "0.5.0.9000"
 
 # This is the version of the Shinylive assets to use.
 SHINYLIVE_ASSETS_VERSION = "0.5.0"

--- a/tests/test_assets.py
+++ b/tests/test_assets.py
@@ -1,4 +1,4 @@
-"""Tests for Shinlyive assets."""
+"""Tests for Shinylive assets."""
 
 import os
 

--- a/tests/test_deps.py
+++ b/tests/test_deps.py
@@ -42,6 +42,11 @@ def test_module_to_package_key():
 
     assert module_to_package_key("cv2") == "opencv-python"
     assert module_to_package_key("black") == "black"
+    assert module_to_package_key("jinja2") == "jinja2"
+
+    # Should be case sensitive for module names.
+    assert module_to_package_key("Jinja2") is None
+
     assert module_to_package_key("foobar") is None
 
 
@@ -63,6 +68,10 @@ def test_dep_name_to_dep_key():
     assert dep_name_to_dep_key("JiNJa2") == "jinja2"
 
     assert dep_name_to_dep_key("cv2") is None
+
+    # Special case for a base pyodide package. It is not in pyodide_lock.json but should
+    # be included in the list of dependencies.
+    assert dep_name_to_dep_key("distutils") == "distutils"
 
 
 def test_find_recursive_deps():

--- a/tests/test_deps.py
+++ b/tests/test_deps.py
@@ -40,7 +40,7 @@ def test_module_to_package_key():
 
     assert module_to_package_key("cv2") == "opencv-python"
     assert module_to_package_key("black") == "black"
-    assert module_to_package_key("foobar") == None
+    assert module_to_package_key("foobar") is None
 
 
 def test_dep_name_to_dep_key():
@@ -54,13 +54,13 @@ def test_dep_name_to_dep_key():
     )
 
     # Should not convert `_` to `-`
-    assert dep_name_to_dep_key("typing_extensions") == None
+    assert dep_name_to_dep_key("typing_extensions") is None
 
     # Should be case insensitive to input.
     assert dep_name_to_dep_key("Jinja2") == "jinja2"
     assert dep_name_to_dep_key("JiNJa2") == "jinja2"
 
-    assert dep_name_to_dep_key("cv2") == None
+    assert dep_name_to_dep_key("cv2") is None
 
 
 def test_find_recursive_deps():

--- a/tests/test_deps.py
+++ b/tests/test_deps.py
@@ -1,5 +1,9 @@
 """Tests for Shinylive dependency detection."""
 
+import os
+
+import pytest
+
 
 def test_requirements_txt():
     from shinylive._deps import _find_packages_in_requirements
@@ -19,6 +23,16 @@ def test_requirements_txt():
     # Should preserve case here (in other steps it will be lowercased).
     assert _find_packages_in_requirements("Jinja2") == ["Jinja2"]
     assert _find_packages_in_requirements("jinja2") == ["jinja2"]
+
+
+# Don't run remaining tests in CI, unless we're triggered by a release event. This is
+# because they require the assets to be installed. In the future, it would make sense to
+# run this test when we're on an rc branch.
+if os.environ.get("CI") == "true" and os.environ.get("GITHUB_EVENT_NAME") != "release":
+    pytest.skip(
+        reason="Don't run this test in CI, unless we're on a release branch.",
+        allow_module_level=True,
+    )
 
 
 def test_module_to_package_key():

--- a/tests/test_deps.py
+++ b/tests/test_deps.py
@@ -25,9 +25,11 @@ def test_requirements_txt():
     assert _find_packages_in_requirements("jinja2") == ["jinja2"]
 
 
+# ======================================================================================
 # Don't run remaining tests in CI, unless we're triggered by a release event. This is
 # because they require the assets to be installed. In the future, it would make sense to
 # run this test when we're on an rc branch.
+# ======================================================================================
 if os.environ.get("CI") == "true" and os.environ.get("GITHUB_EVENT_NAME") != "release":
     pytest.skip(
         reason="Don't run this test in CI, unless we're on a release branch.",

--- a/tests/test_deps.py
+++ b/tests/test_deps.py
@@ -1,0 +1,71 @@
+"""Tests for Shinylive dependency detection."""
+
+
+def test_requirements_txt():
+    from shinylive._deps import _find_packages_in_requirements
+
+    requirements_txt = """
+    typing_extensions
+    jsonschema-specifications (<1.0)
+    # comment
+    """
+
+    # This should convert '_' to '-', and remove the version constraints.
+    assert _find_packages_in_requirements(requirements_txt) == [
+        "typing-extensions",
+        "jsonschema-specifications",
+    ]
+
+    # Should preserve case here (in other steps it will be lowercased).
+    assert _find_packages_in_requirements("Jinja2") == ["Jinja2"]
+    assert _find_packages_in_requirements("jinja2") == ["jinja2"]
+
+
+def test_module_to_package_key():
+    from shinylive._deps import module_to_package_key
+
+    assert module_to_package_key("cv2") == "opencv-python"
+    assert module_to_package_key("black") == "black"
+    assert module_to_package_key("foobar") == None
+
+
+def test_dep_name_to_dep_key():
+    from shinylive._deps import dep_name_to_dep_key
+
+    assert dep_name_to_dep_key("black") == "black"
+    assert dep_name_to_dep_key("typing-extensions") == "typing-extensions"
+    assert (
+        dep_name_to_dep_key("jsonschema_specifications-tests")
+        == "jsonschema-specifications-tests"
+    )
+
+    # Should not convert `_` to `-`
+    assert dep_name_to_dep_key("typing_extensions") == None
+
+    # Should be case insensitive to input.
+    assert dep_name_to_dep_key("Jinja2") == "jinja2"
+    assert dep_name_to_dep_key("JiNJa2") == "jinja2"
+
+    assert dep_name_to_dep_key("cv2") == None
+
+
+def test_find_recursive_deps():
+    from shinylive._deps import _find_recursive_deps
+
+    # It is possible that these dependencies will change in future versions of Pyodide,
+    # but the reason we're testing jsonschema specifically is because it includes
+    # jsonschema_specifications, which is the package name (and not the key).
+    assert sorted(_find_recursive_deps(["jsonschema"])) == [
+        "attrs",
+        "jsonschema",
+        "jsonschema_specifications",
+        "pyrsistent",
+        "referencing",
+        "rpds-py",
+        "six",
+    ]
+
+    assert sorted(_find_recursive_deps(["opencv-python"])) == [
+        "numpy",
+        "opencv-python",
+    ]


### PR DESCRIPTION
This should fix https://github.com/posit-dev/py-shiny-site/pull/186.

For some packages, the entry in pyodide-lock.json has a key like `jsonschema-specifications`, but in that entry, the value `name` field is `jsonschema_specifications`. (And further note that these can differ from the _module name_, which is listed in `imports`). As far as I can tell, there are no fixed rules for how these names relate.

Here are some entries in pyodide-lock.json where these things are not consistent (I've removed extraneous information from these entries to make it easy to see the inconsistencies):
 

```
    "jsonschema-specifications": {
      "depends": [],
      "imports": ["jsonschema_specifications"],
      "name": "jsonschema_specifications",
    }

    "jsonschema-specifications-tests": {
      "depends": ["jsonschema_specifications"],
      "imports": [],
      "name": "jsonschema_specifications-tests",
    }


    "jinja2": {
      "depends": ["markupsafe"],
      "imports": ["jinja2"],
      "name": "Jinja2",
    }

    // In this case the `imports` entry differs from the `name` entry and the key.
    "opencv-python": {
      "depends": ["numpy"],
      "imports": ["cv2"],
      "name": "opencv-python",
    }
```


We already handled the differing module name before. This PR adds support for differences between the key and the name.