### PR TITLE
Ensure shinylive assets are available for unit tests

### DIFF
--- a/tests/test_assets.py
+++ b/tests/test_assets.py
@@ -9,10 +9,6 @@ import shinylive._assets
 
 # Don't run this test in CI, unless we're triggered by a release event. In the future,
 # it would make sense to run this test when we're on an rc branch.
-@pytest.mark.skipif(
-    os.environ.get("CI") == "true" and os.environ.get("GITHUB_EVENT_NAME") != "release",
-    reason="Don't run this test in CI, unless we're on a release branch.",
-)
 def test_assets_available():
     """
     Test that the assets are available at the remote URL. Although this test might not

--- a/tests/test_assets.py
+++ b/tests/test_assets.py
@@ -6,9 +6,17 @@ import pytest
 
 import shinylive._assets
 
-
 # Don't run this test in CI, unless we're triggered by a release event. In the future,
 # it would make sense to run this test when we're on an rc branch.
+skip_if_not_release = (
+    os.environ.get("CI") == "true" and os.environ.get("GITHUB_EVENT_NAME") != "release"
+)
+
+
+@pytest.mark.skipif(
+    skip_if_not_release,
+    reason="Don't run this test in CI, unless we're on a release branch.",
+)
 def test_assets_available():
     """
     Test that the assets are available at the remote URL. Although this test might not

--- a/tests/test_deps.py
+++ b/tests/test_deps.py
@@ -32,11 +32,6 @@ def test_requirements_txt():
 # because they require the assets to be installed. In the future, it would make sense to
 # run this test when we're on an rc branch.
 # ======================================================================================
-if os.environ.get("CI") == "true":
-    pytest.skip(
-        reason="Don't run this test in CI, unless we're on a release branch.",
-        allow_module_level=True,
-    )
 
 
 ensure_shinylive_assets()

--- a/tests/test_deps.py
+++ b/tests/test_deps.py
@@ -36,8 +36,6 @@ skip_if_not_release = (
     os.environ.get("CI") == "true" and os.environ.get("GITHUB_EVENT_NAME") != "release"
 )
 
-skip_if_not_release = False
-
 
 @pytest.mark.skipif(
     skip_if_not_release,

--- a/tests/test_deps.py
+++ b/tests/test_deps.py
@@ -36,6 +36,8 @@ skip_if_not_release = (
     os.environ.get("CI") == "true" and os.environ.get("GITHUB_EVENT_NAME") != "release"
 )
 
+skip_if_not_release = False
+
 
 @pytest.mark.skipif(
     skip_if_not_release,

--- a/tests/test_deps.py
+++ b/tests/test_deps.py
@@ -32,12 +32,18 @@ def test_requirements_txt():
 # because they require the assets to be installed. In the future, it would make sense to
 # run this test when we're on an rc branch.
 # ======================================================================================
+skip_if_not_release = (
+    os.environ.get("CI") == "true" and os.environ.get("GITHUB_EVENT_NAME") != "release"
+)
 
 
-ensure_shinylive_assets()
-
-
+@pytest.mark.skipif(
+    skip_if_not_release,
+    reason="Don't run this test in CI, unless we're on a release branch.",
+)
 def test_module_to_package_key():
+    ensure_shinylive_assets()
+
     from shinylive._deps import module_to_package_key
 
     assert module_to_package_key("cv2") == "opencv-python"
@@ -50,7 +56,13 @@ def test_module_to_package_key():
     assert module_to_package_key("foobar") is None
 
 
+@pytest.mark.skipif(
+    skip_if_not_release,
+    reason="Don't run this test in CI, unless we're on a release branch.",
+)
 def test_dep_name_to_dep_key():
+    ensure_shinylive_assets()
+
     from shinylive._deps import dep_name_to_dep_key
 
     assert dep_name_to_dep_key("black") == "black"
@@ -74,7 +86,13 @@ def test_dep_name_to_dep_key():
     assert dep_name_to_dep_key("distutils") == "distutils"
 
 
+@pytest.mark.skipif(
+    skip_if_not_release,
+    reason="Don't run this test in CI, unless we're on a release branch.",
+)
 def test_find_recursive_deps():
+    ensure_shinylive_assets()
+
     from shinylive._deps import _find_recursive_deps
 
     # It is possible that these dependencies will change in future versions of Pyodide,

--- a/tests/test_deps.py
+++ b/tests/test_deps.py
@@ -4,6 +4,8 @@ import os
 
 import pytest
 
+from shinylive._assets import ensure_shinylive_assets
+
 
 def test_requirements_txt():
     from shinylive._deps import _find_packages_in_requirements
@@ -30,11 +32,14 @@ def test_requirements_txt():
 # because they require the assets to be installed. In the future, it would make sense to
 # run this test when we're on an rc branch.
 # ======================================================================================
-if os.environ.get("CI") == "true" and os.environ.get("GITHUB_EVENT_NAME") != "release":
+if os.environ.get("CI") == "true":
     pytest.skip(
         reason="Don't run this test in CI, unless we're on a release branch.",
         allow_module_level=True,
     )
+
+
+ensure_shinylive_assets()
 
 
 def test_module_to_package_key():


### PR DESCRIPTION
When making a release, extra tests where hit and broken.