### PR TITLE
Show status when downloading assets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [UNRELEASED]
+
+* Download status is now displayed while downloading Shinylive assets.
 
 ## [0.6.0] - 2024-09-03
 

--- a/shinylive/_assets.py
+++ b/shinylive/_assets.py
@@ -50,7 +50,9 @@ def download_shinylive(
             progress_size = int(count * block_size)
             speed = int(progress_size / (1024 * duration))
             percent = min(int(count * block_size * 100 / total_size), 100)
-            sys.stderr.write(f"\r{percent}%, {speed} KB/s, {progress_size / (1024 * 1024):.1f}/{total_size / (1024 * 1024):.1f} MB")
+            sys.stderr.write(
+                f"\r{percent}%, {speed} KB/s, {progress_size / (1024 * 1024):.1f}/{total_size / (1024 * 1024):.1f} MB"
+            )
             sys.stderr.flush()
             last_update_time = current_time
 

--- a/shinylive/_assets.py
+++ b/shinylive/_assets.py
@@ -4,6 +4,7 @@ import os
 import re
 import shutil
 import sys
+import time
 import urllib.request
 from pathlib import Path
 from typing import Optional
@@ -30,7 +31,27 @@ def download_shinylive(
 
     try:
         print(f"Downloading {url}...", file=sys.stderr)
-        tmp_name, _ = urllib.request.urlretrieve(url)
+
+        start_time = time.time()
+        last_update_time = start_time
+
+        def reporthook(count: int, block_size: int, total_size: int):
+            nonlocal last_update_time
+            current_time = time.time()
+
+            if current_time - last_update_time < 1:
+                return
+
+            duration = current_time - start_time
+            progress_size = int(count * block_size)
+            speed = int(progress_size / (1024 * duration))
+            percent = min(int(count * block_size * 100 / total_size), 100)
+            sys.stderr.write(f"\r{percent}%, {speed} KB/s, {progress_size / (1024 * 1024):.1f}/{total_size / (1024 * 1024):.1f} MB")
+            sys.stderr.flush()
+            last_update_time = current_time
+
+        tmp_name, _ = urllib.request.urlretrieve(url, reporthook=reporthook)
+        sys.stderr.write("\n")
 
         print(f"Unzipping to {destdir}/", file=sys.stderr)
         tar_safe_extractall(tmp_name, destdir)

--- a/shinylive/_assets.py
+++ b/shinylive/_assets.py
@@ -17,6 +17,7 @@ def download_shinylive(
     destdir: str | Path | None = None,
     version: str = SHINYLIVE_ASSETS_VERSION,
     url: Optional[str] = None,
+    status: bool = True,
 ) -> None:
     if destdir is None:
         # Note that this is the cache directory, which is the parent of the assets
@@ -36,6 +37,9 @@ def download_shinylive(
         last_update_time = start_time
 
         def reporthook(count: int, block_size: int, total_size: int):
+            if not status:
+                return
+
             nonlocal last_update_time
             current_time = time.time()
 

--- a/shinylive/_main.py
+++ b/shinylive/_main.py
@@ -240,7 +240,9 @@ def download(
 ) -> None:
     if version is None:  # pyright: ignore[reportUnnecessaryComparison]
         version = SHINYLIVE_ASSETS_VERSION
-    _assets.download_shinylive(destdir=upgrade_dir(dir), version=version, url=url, status=status)
+    _assets.download_shinylive(
+        destdir=upgrade_dir(dir), version=version, url=url, status=status
+    )
 
 
 cleanup_help = f"Remove all versions of local assets except the currently-used version, {SHINYLIVE_ASSETS_VERSION}."

--- a/shinylive/_main.py
+++ b/shinylive/_main.py
@@ -226,14 +226,21 @@ def assets_info(
     default=None,
     help="URL to download from. If used, this will override --version.",
 )
+@click.option(
+    "--status/--no-status",
+    is_flag=True,
+    default=True,
+    help="Enable/disable status output during download.",
+)
 def download(
     version: str,
     dir: Optional[str | Path],
     url: Optional[str],
+    status: bool,
 ) -> None:
     if version is None:  # pyright: ignore[reportUnnecessaryComparison]
         version = SHINYLIVE_ASSETS_VERSION
-    _assets.download_shinylive(destdir=upgrade_dir(dir), version=version, url=url)
+    _assets.download_shinylive(destdir=upgrade_dir(dir), version=version, url=url, status=status)
 
 
 cleanup_help = f"Remove all versions of local assets except the currently-used version, {SHINYLIVE_ASSETS_VERSION}."


### PR DESCRIPTION
This change makes it so that the asset download status is printed, and updated every 1 second. This is helpful when on a not-super-fast internet connection so that the user has an idea what is happening and how long they will have to wait.

```
❯ shinylive assets download
Downloading https://github.com/posit-dev/shinylive/releases/download/v0.7.0/shinylive-0.7.0.tar.gz...
5%, 6604 KB/s, 20.4/343.6 MB
```

It adds an option `--no-status` to disable the displaying of the status. However, as of right now, that option is only available when running `shinylive assets download`. It's not there if you run `shinylive export ...` and the assets are automatically downloaded. I think that's OK, since I believe it would be an unusual case where someone wants to run `shinylive export` _and_ suppress the status, and for those use cases, they could just run `shinylive assets download --no-status` first.